### PR TITLE
RESULTS.rst: match formatting on the wiki (except ffmpeg)

### DIFF
--- a/results/RESULTS.rst
+++ b/results/RESULTS.rst
@@ -6,7 +6,7 @@ Getting useful results output from:
 xz
 --
 
-``grep real xz-test*`` 
+``grep real xz-test* | awk '{print $2}' | awk '!(NR%2){printf(NR/2)":"p":";print$0"  "}{p=$0}'``
 
 ffmpeg
 ------
@@ -16,4 +16,4 @@ ffmpeg
 unixbench
 ---------
 
-``grep "Index Score" unixbench-test*``
+``grep "Index Score" unixbench-test* | awk '{print $5}' | awk '!(NR%2){printf(NR/2)":"p":";print$0"  "}{p=$0}'``


### PR DESCRIPTION
Use results-processing utilities to provide output that matches formatting on the wiki. Sorry there's no such one-liner for ffmpeg; I had trouble getting results from it.
